### PR TITLE
Kafka Integration

### DIFF
--- a/bin/collector
+++ b/bin/collector
@@ -3,4 +3,4 @@
 DEFAULT_TYPE=dev
 SERVICE_TYPE=${1:-$DEFAULT_TYPE}
 
-bin/sbt 'project zipkin-collector-service' "run -f zipkin-collector-service/config/collector-${SERVICE_TYPE}.scala"
+bin/sbt 'project zipkin-collector-service' "run zipkin-collector-service/config/collector-${SERVICE_TYPE}.scala"

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -368,7 +368,8 @@ object Zipkin extends Build {
     ).settings(
       libraryDependencies ++= Seq(
         twitterServer,
-        "com.twitter" %% "tormenta-kafka" % "0.8.0",
+        "org.apache.kafka" % "kafka_2.10" % "0.8.1.1",
+        "org.apache.commons" % "commons-io" % "1.3.2",
         scroogeDep("serializer")
       ) ++ scalaTestDeps
     ).dependsOn(common, collector, zookeeper, scrooge)
@@ -380,7 +381,7 @@ object Zipkin extends Build {
       settings = defaultSettings
     ).settings(
       libraryDependencies ++= Seq(
-        "com.twitter" %% "tormenta-kafka" % "0.8.0",
+        "org.apache.kafka" % "kafka_2.10" % "0.8.1.1",
         scroogeDep("serializer")
       ) ++ testDependencies,
       resolvers ++= (proxyRepo match {

--- a/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/Main.scala
+++ b/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/Main.scala
@@ -14,37 +14,6 @@
  *  limitations under the License.
  *
  */
-// package com.twitter.zipkin.collector
-
-// import com.twitter.logging.Logger
-// import com.twitter.ostrich.admin.{ServiceTracker, RuntimeEnvironment}
-// import com.twitter.util.Eval
-// import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
-// import com.twitter.zipkin.BuildProperties
-
-
-// object Main {
-//   val log = Logger.get(getClass.getName)
-
-//   def main(args: Array[String]) {
-//     log.info("Loading configuration")
-//     val runtime = RuntimeEnvironment(BuildProperties, args)
-//     val builder = (new Eval).apply[CollectorServiceBuilder[Seq[String]]](runtime.configFile)
-//     try {
-//       val server = builder.apply().apply(runtime)
-//       server.start()
-//       ServiceTracker.register(server)
-//     } catch {
-//       case e: Exception =>
-//         e.printStackTrace()
-//         log.error(e, "Unexpected exception: %s", e.getMessage)
-//         System.exit(0)
-//     }
-//   }
-// }
-
-
-
 
 import com.twitter.zipkin.gen.{Span => ThriftSpan}
 import com.twitter.finagle.stats.StatsReceiver
@@ -58,7 +27,6 @@ import com.twitter.zipkin.storage.WriteSpanStore
 import com.twitter.zipkin.zookeeper.ZooKeeperClientFactory
 import kafka.serializer.Decoder
 
-// JW: added this
 import com.twitter.zipkin.receiver.kafka.SpanDecoder
 
 object ZipkinKafkaCollectorServer extends TwitterServer

--- a/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/Main.scala
+++ b/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/Main.scala
@@ -14,31 +14,68 @@
  *  limitations under the License.
  *
  */
-package com.twitter.zipkin.collector
+// package com.twitter.zipkin.collector
 
-import com.twitter.logging.Logger
-import com.twitter.ostrich.admin.{ServiceTracker, RuntimeEnvironment}
-import com.twitter.util.Eval
-import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
-import com.twitter.zipkin.BuildProperties
+// import com.twitter.logging.Logger
+// import com.twitter.ostrich.admin.{ServiceTracker, RuntimeEnvironment}
+// import com.twitter.util.Eval
+// import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
+// import com.twitter.zipkin.BuildProperties
 
 
-object Main {
-  val log = Logger.get(getClass.getName)
+// object Main {
+//   val log = Logger.get(getClass.getName)
 
-  def main(args: Array[String]) {
-    log.info("Loading configuration")
-    val runtime = RuntimeEnvironment(BuildProperties, args)
-    val builder = (new Eval).apply[CollectorServiceBuilder[Seq[String]]](runtime.configFile)
-    try {
-      val server = builder.apply().apply(runtime)
-      server.start()
-      ServiceTracker.register(server)
-    } catch {
-      case e: Exception =>
-        e.printStackTrace()
-        log.error(e, "Unexpected exception: %s", e.getMessage)
-        System.exit(0)
-    }
+//   def main(args: Array[String]) {
+//     log.info("Loading configuration")
+//     val runtime = RuntimeEnvironment(BuildProperties, args)
+//     val builder = (new Eval).apply[CollectorServiceBuilder[Seq[String]]](runtime.configFile)
+//     try {
+//       val server = builder.apply().apply(runtime)
+//       server.start()
+//       ServiceTracker.register(server)
+//     } catch {
+//       case e: Exception =>
+//         e.printStackTrace()
+//         log.error(e, "Unexpected exception: %s", e.getMessage)
+//         System.exit(0)
+//     }
+//   }
+// }
+
+
+
+
+import com.twitter.zipkin.gen.{Span => ThriftSpan}
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.server.TwitterServer
+import com.twitter.util.{Await, Future}
+import com.twitter.zipkin.cassandra.CassieSpanStoreFactory
+import com.twitter.zipkin.collector.{SpanReceiver, ZipkinQueuedCollectorFactory}
+import com.twitter.zipkin.common._
+import com.twitter.zipkin.receiver.kafka.KafkaSpanReceiverFactory
+import com.twitter.zipkin.storage.WriteSpanStore
+import com.twitter.zipkin.zookeeper.ZooKeeperClientFactory
+import kafka.serializer.Decoder
+
+// JW: added this
+import com.twitter.zipkin.receiver.kafka.SpanDecoder
+
+object ZipkinKafkaCollectorServer extends TwitterServer
+  with ZipkinQueuedCollectorFactory
+  with CassieSpanStoreFactory
+  with ZooKeeperClientFactory
+  with KafkaSpanReceiverFactory
+{
+  def newReceiver(receive: Seq[ThriftSpan] => Future[Unit], stats: StatsReceiver): SpanReceiver =
+    newKafkaSpanReceiver(receive, stats.scope("kafkaSpanReceiver"), new SpanDecoder())
+
+  def newSpanStore(stats: StatsReceiver): WriteSpanStore =
+    newCassandraStore(stats.scope("cassie"))
+
+  def main() {
+    val collector = newCollector(statsReceiver)
+    onExit { collector.close() }
+    Await.ready(collector)
   }
 }

--- a/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/Main.scala
+++ b/zipkin-collector-service/src/main/scala/com/twitter/zipkin/collector/Main.scala
@@ -14,8 +14,7 @@
  *  limitations under the License.
  *
  */
-
-import com.twitter.zipkin.gen.{Span => ThriftSpan}
+import com.twitter.zipkin.thriftscala.{Span => ThriftSpan}
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.server.TwitterServer
 import com.twitter.util.{Await, Future}

--- a/zipkin-gems/zipkin-tracer/.gitignore
+++ b/zipkin-gems/zipkin-tracer/.gitignore
@@ -1,0 +1,31 @@
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalisation:
+/.bundle/
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+.ruby-version
+.ruby-gemset

--- a/zipkin-gems/zipkin-tracer/Gemfile.lock
+++ b/zipkin-gems/zipkin-tracer/Gemfile.lock
@@ -1,0 +1,65 @@
+PATH
+  remote: .
+  specs:
+    lookout-zipkin-tracer (0.4.0-java)
+      finagle-thrift (~> 1.3.0)
+      hermann (~> 0.20.1)
+      rack
+      scribe (~> 0.2.4)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    concurrent-ruby (0.7.1-java)
+    diff-lcs (1.2.5)
+    finagle-thrift (1.3.1)
+    hermann (0.20.1-java)
+      concurrent-ruby (~> 0.7.0)
+      jar-dependencies (~> 0.1.2)
+      thread_safe (~> 0.3.4)
+      zk (~> 1.9.4)
+    jar-dependencies (0.1.7)
+    little-plugger (1.1.3)
+    logging (1.8.2)
+      little-plugger (>= 1.1.3)
+      multi_json (>= 1.8.4)
+    multi_json (1.10.1)
+    rack (1.6.0)
+    rack-test (0.6.2)
+      rack (>= 1.0)
+    rake (10.4.2)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+    rspec-core (3.0.4)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.4)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.4)
+    scribe (0.2.4)
+      rake
+      thrift_client (~> 0.6)
+    slyphon-log4j (1.2.15)
+    slyphon-zookeeper_jar (3.3.5-java)
+    thread_safe (0.3.4-java)
+    thrift (0.9.2.0)
+    thrift_client (0.9.3)
+      thrift (~> 0.9.0)
+    zk (1.9.4)
+      logging (~> 1.8.2)
+      zookeeper (~> 1.4.0)
+    zookeeper (1.4.9-java)
+      slyphon-log4j (= 1.2.15)
+      slyphon-zookeeper_jar (= 3.3.5)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  lookout-zipkin-tracer!
+  rack-test
+  rspec (~> 3.0.0)

--- a/zipkin-gems/zipkin-tracer/README.md
+++ b/zipkin-gems/zipkin-tracer/README.md
@@ -22,6 +22,7 @@ where Rails.config.zipkin_tracer or config is a hash that can contain the follow
    response status, headers, and body; and can record annotations
  * `:filter_plugin` - plugin function which recieves Rack env and will skip tracing if it returns false
  * `:whitelist_plugin` - plugin function which recieves Rack env and will force sampling if it returns true
+ * `:zookeeper` - plugin function which uses zookeeper and kafka instead of scribe as the transport
 
 ## Warning
 

--- a/zipkin-gems/zipkin-tracer/lib/zipkin-tracer.rb
+++ b/zipkin-gems/zipkin-tracer/lib/zipkin-tracer.rb
@@ -36,7 +36,7 @@ module ZipkinTracer extend self
         scribe = config[:scribe_server] ? Scribe.new(config[:scribe_server]) : Scribe.new()
         careless_scribe = CarelessScribe.new(scribe)
         scribe_max_buffer = config[:scribe_max_buffer] ? config[:scribe_max_buffer] : 10
-        # ::Trace.tracer = ::Trace::ZipkinTracer.new(careless_scribe, scribe_max_buffer)
+        ::Trace.tracer = ::Trace::ZipkinTracer.new(careless_scribe, scribe_max_buffer)
       elsif config[:zookeeper]
         ::Trace.tracer = ::Trace::ZipkinKafkaTracer.new(config[:zookeeper])
       end

--- a/zipkin-gems/zipkin-tracer/lib/zipkin-tracer/version.rb
+++ b/zipkin-gems/zipkin-tracer/lib/zipkin-tracer/version.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end
 

--- a/zipkin-gems/zipkin-tracer/lib/zipkin-tracer/zipkin_kafka_tracer.rb
+++ b/zipkin-gems/zipkin-tracer/lib/zipkin-tracer/zipkin_kafka_tracer.rb
@@ -37,28 +37,28 @@ module Trace
     end
 
     private
-    def get_span_for_id(id)
-      key = id.span_id.to_s
-      @spans[key] ||= begin
-        Span.new("", id)
+      def get_span_for_id(id)
+        key = id.span_id.to_s
+        @spans[key] ||= begin
+          Span.new("", id)
+        end
       end
-    end
 
-    def flush!
-      begin
-        messages = @spans.values.map do |span|
-          buf = ''
-          trans = Thrift::MemoryBufferTransport.new(buf)
-          oprot = Thrift::BinaryProtocol.new(trans)
-          span.to_thrift.write(oprot)
-          @producer.push(buf, :topic => @topic).value!
-        end
-      rescue => e
-        if @logger
-          @logger.error("Exception: #{e.message}")
-          @logger.error(e.backtrace.join("\n"))
+      def flush!
+        begin
+          messages = @spans.values.map do |span|
+            buf = ''
+            trans = Thrift::MemoryBufferTransport.new(buf)
+            oprot = Thrift::BinaryProtocol.new(trans)
+            span.to_thrift.write(oprot)
+            @producer.push(buf, :topic => @topic).value!
+          end
+        rescue => e
+          if @logger
+            @logger.error("Exception: #{e.message}")
+            @logger.error(e.backtrace.join("\n"))
+          end
         end
       end
-    end
   end
 end

--- a/zipkin-gems/zipkin-tracer/lib/zipkin-tracer/zipkin_kafka_tracer.rb
+++ b/zipkin-gems/zipkin-tracer/lib/zipkin-tracer/zipkin_kafka_tracer.rb
@@ -1,0 +1,74 @@
+require 'finagle-thrift'
+require 'finagle-thrift/tracer'
+require 'hermann'
+require 'hermann/producer'
+require 'hermann/discovery/zookeeper'
+
+module Trace
+  class ZipkinKafkaTracer < Tracer
+    TRACER_CATEGORY = "zipkin"
+    KAFKA_TOPIC = "zipkin_kafka"
+
+    def initialize(zookeepers)
+      broker_ids = Hermann::Discovery::Zookeeper.new(zookeepers).get_brokers
+      @producer = Hermann::Producer.new(nil, broker_ids)
+      reset
+    end
+
+    def record(id, annotation)
+      return unless id.sampled?
+      span = get_span_for_id(id)
+
+      case annotation
+      when BinaryAnnotation
+        span.binary_annotations << annotation
+      when Annotation
+        span.annotations << annotation
+      end
+
+      @count += 1
+      # if @count >= @max_buffer || (annotation.is_a?(Annotation) && annotation.value == Annotation::SERVER_SEND)
+        flush!
+      # end
+    end
+
+    def set_rpc_name(id, name)
+      return unless id.sampled?
+      span = get_span_for_id(id)
+      span.name = name.to_s
+    end
+
+    private
+    def get_span_for_id(id)
+      key = id.span_id.to_s
+      @spans[key] ||= begin
+        Span.new("", id)
+      end
+    end
+
+    def reset
+      @count = 0
+      @spans = {}
+    end
+
+    def flush!
+      # @scribe.batch do
+      begin
+        messages = @spans.values.map do |span|
+          buf = ''
+          trans = Thrift::MemoryBufferTransport.new(buf)
+          oprot = Thrift::BinaryProtocol.new(trans)
+          span.to_thrift.write(oprot)
+          # binary = Base64.encode64(buf).gsub("\n", "")
+          # @scribe.log(binary, TRACER_CATEGORY)
+          @producer.push(buf, :topic => KAFKA_TOPIC).value!
+        end
+      rescue => e
+        puts "....Exception: #{e.message}"
+        puts e.backtrace.join("\n")
+      end
+
+      reset
+    end
+  end
+end

--- a/zipkin-gems/zipkin-tracer/spec/rack_handler_spec.rb
+++ b/zipkin-gems/zipkin-tracer/spec/rack_handler_spec.rb
@@ -22,6 +22,17 @@ describe ZipkinTracer::RackHandler do
     allow(::Trace::Endpoint).to receive(:host_to_i32).and_return(host_ip)
   }
 
+  context 'configured to use kafka' do
+    let(:zookeeper) { 'localhost:2181' }
+    let(:zipkinKafkaTracer) { double('ZipkinKafkaTracer') }
+
+    it 'creates a zipkin kafka tracer' do
+      allow(::Trace::ZipkinKafkaTracer).to receive(:new) { zipkinKafkaTracer }
+      expect(::Trace).to receive(:tracer=).with(zipkinKafkaTracer)
+      middleware(app, :zookeeper => zookeeper)
+    end
+  end
+
   context 'configured without plugins' do
     subject { middleware(app) }
 

--- a/zipkin-gems/zipkin-tracer/spec/zipkin_kafka_tracer_spec.rb
+++ b/zipkin-gems/zipkin-tracer/spec/zipkin_kafka_tracer_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+
+describe Trace::ZipkinKafkaTracer do
+  let(:zookeepers) { 'localhost:2181' }
+  let(:zk) { double('broker_ids') }
+  let(:id)                { double('id') }
+  let(:span)              { double('span') }
+
+  before do
+    allow(Hermann::Discovery::Zookeeper).to receive(:new) { zk }
+    allow(zk).to receive(:get_brokers)
+    allow(Hermann::Producer).to receive(:new)
+  end
+
+  describe '#initialize' do
+    context 'with default settings' do
+      subject { described_class.new(zookeepers)}
+
+      it 'has nil logger' do
+        expect(subject.instance_variable_get(:@logger)).to be nil
+      end
+
+      it 'has default topic' do
+        expect(subject.instance_variable_get(:@topic)).to eq Trace::ZipkinKafkaTracer::DEFAULT_KAFKA_TOPIC
+      end
+    end
+
+    context 'with options' do
+      let(:logger) { double('logger') }
+      let(:topic)  { 'topic' }
+
+      subject { described_class.new(zookeepers, {:logger => logger, :topic => topic})}
+
+      it 'has logger' do
+        expect(subject.instance_variable_get(:@logger)).to be logger
+      end
+
+      it 'has an optional topic' do
+        expect(subject.instance_variable_get(:@topic)).to eq topic
+      end
+    end
+  end
+
+  describe '#record' do
+    module Trace
+      class BinaryAnnotation
+        def initialize;end
+      end
+      class Annotation
+        def initialize;end
+      end
+    end
+
+    subject { described_class.new(zookeepers)}
+
+    let(:binary_annotation) { ::Trace::BinaryAnnotation.new }
+    let(:annotation)        { ::Trace::Annotation.new }
+
+    it 'returns if id already sampled' do
+      allow(id).to receive(:sampled?) { false }
+      expect(subject).to_not receive(:get_span_for_id)
+      subject.record(id, annotation)
+    end
+
+    context 'processing annotation' do
+      before do
+        allow(id).to receive(:sampled?) { true }
+        allow(subject).to receive(:get_span_for_id) { span }
+        expect(subject).to receive(:flush!)
+      end
+
+      it 'records a binary annotation' do
+        expect(span).to receive(:binary_annotations) { [] }
+        subject.record(id, binary_annotation)
+      end
+      it 'records an annotation' do
+        expect(span).to receive(:annotations) { [] }
+        subject.record(id, annotation)
+      end
+    end
+  end
+
+  describe '#set_rpc_name' do
+    subject { described_class.new(zookeepers)}
+
+    let(:name) { 'name' }
+
+    it 'returns if id already sampled' do
+      allow(id).to receive(:sampled?) { false }
+      expect(subject).to_not receive(:get_span_for_id)
+      subject.set_rpc_name(id, name)
+    end
+
+    it 'sets the span name' do
+      allow(id).to receive(:sampled?) { true }
+      allow(subject).to receive(:get_span_for_id) { span }
+      expect(span).to receive(:name=).with(name)
+      subject.set_rpc_name(id, name)
+    end
+  end
+end

--- a/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
+++ b/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "rack-test"
-  s.add_development_dependency "thin" # allow testing with thrift v0.9.1
+  # s.add_development_dependency "thin" # allow testing with thrift v0.9.1
 end

--- a/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
+++ b/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
@@ -35,6 +35,11 @@ Gem::Specification.new do |s|
   s.add_dependency "scribe", "~> 0.2.4"
   s.add_dependency "rack"
 
+  if RUBY_PLATFORM == "java"
+    s.add_dependency 'hermann', "~> 0.20.1"
+    s.platform = 'java'
+  end
+
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "rack-test"
   s.add_development_dependency "thin" # allow testing with thrift v0.9.1

--- a/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
+++ b/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
@@ -42,5 +42,4 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "rack-test"
-  # s.add_development_dependency "thin" # allow testing with thrift v0.9.1
 end

--- a/zipkin-kafka/src/main/scala/com/twitter/zipkin/collector/Kafka.scala
+++ b/zipkin-kafka/src/main/scala/com/twitter/zipkin/collector/Kafka.scala
@@ -25,8 +25,7 @@ import com.twitter.zipkin.common.Span
 import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.thriftscala
 import kafka.message.Message
-import kafka.producer.Producer
-import kafka.producer.KeyedMessage
+import kafka.producer.{Producer, KeyedMessage}
 import kafka.serializer.Encoder
 import java.nio.charset.StandardCharsets
 

--- a/zipkin-kafka/src/main/scala/com/twitter/zipkin/collector/Kafka.scala
+++ b/zipkin-kafka/src/main/scala/com/twitter/zipkin/collector/Kafka.scala
@@ -25,8 +25,10 @@ import com.twitter.zipkin.common.Span
 import com.twitter.zipkin.conversions.thrift._
 import com.twitter.zipkin.thriftscala
 import kafka.message.Message
-import kafka.producer.{ProducerData, Producer}
+import kafka.producer.Producer
+import kafka.producer.KeyedMessage
 import kafka.serializer.Encoder
+import java.nio.charset.StandardCharsets
 
 class Kafka(
   kafka: Producer[String, thriftscala.Span],
@@ -36,11 +38,16 @@ class Kafka(
 
   private[this] val log = Logger.get()
 
+  def send(message: String, partition: String = null): Unit = {
+    send(new String(message.getBytes(StandardCharsets.UTF_8)),
+      if (partition == null) null else new String(partition.getBytes(StandardCharsets.UTF_8)))
+  }
+
   def apply(req: Span): Future[Unit] = {
     statsReceiver.counter("try").incr()
-    val producerData = new ProducerData[String, thriftscala.Span](topic, Seq(req.toThrift))
+
     Future {
-      kafka.send(producerData)
+      kafka.send(new KeyedMessage(topic, req.toThrift))
     } onSuccess { (_) =>
       statsReceiver.counter("success").incr()
     }
@@ -56,6 +63,7 @@ class SpanEncoder extends Encoder[thriftscala.Span] {
   val serializer = new BinaryThriftStructSerializer[thriftscala.Span] {
     def codec = thriftscala.Span
   }
+  def toBytes(span: thriftscala.Span): Array[Byte] = serializer.toBytes(span)
 
   def toMessage(span: thriftscala.Span): Message = {
     new Message(serializer.toBytes(span))

--- a/zipkin-kafka/src/main/scala/com/twitter/zipkin/collector/Kafka.scala
+++ b/zipkin-kafka/src/main/scala/com/twitter/zipkin/collector/Kafka.scala
@@ -36,11 +36,17 @@ class Kafka(
 
   private[this] val log = Logger.get()
 
+
+  def send(message: String, partition: String = null): Unit = {
+    send(new String(message.getBytes(StandardCharsets.UTF_8)),
+      if (partition == null) null else new String(partition.getBytes(StandardCharsets.UTF_8)))
+  }
+
   def apply(req: Span): Future[Unit] = {
     statsReceiver.counter("try").incr()
-    val producerData = new ProducerData[String, thriftscala.Span](topic, Seq(req.toThrift))
+
     Future {
-      kafka.send(producerData)
+      kafka.send(new KeyedMessage(topic, req.toThrift))
     } onSuccess { (_) =>
       statsReceiver.counter("success").incr()
     }
@@ -56,6 +62,8 @@ class SpanEncoder extends Encoder[thriftscala.Span] {
   val serializer = new BinaryThriftStructSerializer[thriftscala.Span] {
     def codec = thriftscala.Span
   }
+
+  def toBytes(span: gen.Span): Array[Byte] = serializer.toBytes(span)
 
   def toMessage(span: thriftscala.Span): Message = {
     new Message(serializer.toBytes(span))

--- a/zipkin-kafka/src/main/scala/com/twitter/zipkin/collector/Kafka.scala
+++ b/zipkin-kafka/src/main/scala/com/twitter/zipkin/collector/Kafka.scala
@@ -27,7 +27,8 @@ import com.twitter.zipkin.thriftscala
 import kafka.message.Message
 import kafka.producer.{Producer, KeyedMessage}
 import kafka.serializer.Encoder
-import java.nio.charset.StandardCharsets
+import java.nio.charset.Charset
+
 
 class Kafka(
   kafka: Producer[String, thriftscala.Span],
@@ -38,8 +39,8 @@ class Kafka(
   private[this] val log = Logger.get()
 
   def send(message: String, partition: String = null): Unit = {
-    send(new String(message.getBytes(StandardCharsets.UTF_8)),
-      if (partition == null) null else new String(partition.getBytes(StandardCharsets.UTF_8)))
+    send(new String(message.getBytes(Charset.forName("UTF-8"))),
+      if (partition == null) null else new String(partition.getBytes(Charset.forName("UTF-8"))))
   }
 
   def apply(req: Span): Future[Unit] = {

--- a/zipkin-kafka/src/main/scala/com/twitter/zipkin/config/KafkaConfig.scala
+++ b/zipkin-kafka/src/main/scala/com/twitter/zipkin/config/KafkaConfig.scala
@@ -1,20 +1,20 @@
-/*
- * Copyright 2012 Twitter Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- */
-package com.twitter.zipkin.config
+// /*
+//  * Copyright 2012 Twitter Inc.
+//  *
+//  * Licensed under the Apache License, Version 2.0 (the "License");
+//  * you may not use this file except in compliance with the License.
+//  * You may obtain a copy of the License at
+//  *
+//  *      http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  *  Unless required by applicable law or agreed to in writing, software
+//  *  distributed under the License is distributed on an "AS IS" BASIS,
+//  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  *  See the License for the specific language governing permissions and
+//  *  limitations under the License.
+//  *
+//  */
+// package com.twitter.zipkin.config
 
 import com.twitter.finagle.stats.{StatsReceiver, NullStatsReceiver}
 import com.twitter.util.Config

--- a/zipkin-kafka/src/main/scala/com/twitter/zipkin/config/KafkaConfig.scala
+++ b/zipkin-kafka/src/main/scala/com/twitter/zipkin/config/KafkaConfig.scala
@@ -1,20 +1,20 @@
-// /*
-//  * Copyright 2012 Twitter Inc.
-//  *
-//  * Licensed under the Apache License, Version 2.0 (the "License");
-//  * you may not use this file except in compliance with the License.
-//  * You may obtain a copy of the License at
-//  *
-//  *      http://www.apache.org/licenses/LICENSE-2.0
-//  *
-//  *  Unless required by applicable law or agreed to in writing, software
-//  *  distributed under the License is distributed on an "AS IS" BASIS,
-//  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  *  See the License for the specific language governing permissions and
-//  *  limitations under the License.
-//  *
-//  */
-// package com.twitter.zipkin.config
+/*
+ * Copyright 2012 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.twitter.zipkin.config
 
 import com.twitter.finagle.stats.{StatsReceiver, NullStatsReceiver}
 import com.twitter.util.Config
@@ -31,10 +31,10 @@ trait KafkaConfig extends Config[Kafka] {
 
   def apply(): Kafka = {
     val properties = new Properties
-    properties.put("zk.connect", zkConnectString)
+    properties.put("zookeeper.connect", zkConnectString)
     properties.put("serializer.class", "com.twitter.zipkin.collector.SpanEncoder")
     properties.put("producer.type", "sync")
-    val producer = new Producer[String, thriftscala.Span](new ProducerConfig(properties))
+    val producer = new Producer[String, gen.Span](new ProducerConfig(properties))
     new Kafka(producer, topic, statsReceiver.scope("kafka"))
   }
 }

--- a/zipkin-kafka/src/main/scala/com/twitter/zipkin/config/KafkaConfig.scala
+++ b/zipkin-kafka/src/main/scala/com/twitter/zipkin/config/KafkaConfig.scala
@@ -34,7 +34,7 @@ trait KafkaConfig extends Config[Kafka] {
     properties.put("zookeeper.connect", zkConnectString)
     properties.put("serializer.class", "com.twitter.zipkin.collector.SpanEncoder")
     properties.put("producer.type", "sync")
-    val producer = new Producer[String, gen.Span](new ProducerConfig(properties))
+    val producer = new Producer[String, thriftscala.Span](new ProducerConfig(properties))
     new Kafka(producer, topic, statsReceiver.scope("kafka"))
   }
 }

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessor.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessor.scala
@@ -37,7 +37,7 @@ class KafkaProcessor(
     val threadCount = topics.foldLeft(0) { case (sum, (_, a)) => sum + a }
     val pool = Executors.newFixedThreadPool(threadCount)
     for {
-      (topic, streams) <- consumerConnector.createMessageStreams(topics, decoder, decoder)
+      (topic, streams) <- consumerConnector.createMessageStreams(topics, decoder)
       stream <- streams
     } pool.submit(new KafkaStreamProcessor(stream, process))
     pool

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessor.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessor.scala
@@ -37,7 +37,7 @@ class KafkaProcessor(
     val threadCount = topics.foldLeft(0) { case (sum, (_, a)) => sum + a }
     val pool = Executors.newFixedThreadPool(threadCount)
     for {
-      (topic, streams) <- consumerConnector.createMessageStreams(topics, decoder)
+      (topic, streams) <- consumerConnector.createMessageStreams(topics, decoder, decoder)
       stream <- streams
     } pool.submit(new KafkaStreamProcessor(stream, process))
     pool

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessor.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessor.scala
@@ -1,7 +1,6 @@
 package com.twitter.zipkin.receiver.kafka
 
 import com.twitter.zipkin.thriftscala.{Span => ThriftSpan}
-import com.twitter.ostrich.admin.{Service => OstrichService, ServiceTracker}
 import kafka.consumer.{Consumer, ConsumerConnector, ConsumerConfig}
 import kafka.serializer.Decoder
 import com.twitter.util.{Closable, CloseAwaitably, FuturePool, Future, Time}
@@ -11,7 +10,6 @@ import java.net.{SocketAddress, InetSocketAddress}
 
 import com.twitter.scrooge.BinaryThriftStructSerializer
 import com.twitter.zipkin.conversions.thrift.{thriftSpanToSpan, spanToThriftSpan}
-import java.io._
 import kafka.message.Message
 
 object KafkaProcessor {

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaSpanReceiver.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaSpanReceiver.scala
@@ -1,13 +1,11 @@
 package com.twitter.zipkin.receiver.kafka
 
-import com.twitter.app.{App, Flaggable}
+import com.twitter.app.App
 import java.util.Properties
 import com.twitter.zipkin.thriftscala.{Span => ThriftSpan}
 import com.twitter.zipkin.collector.SpanReceiver
-import com.twitter.zipkin.conversions.thrift._
 import com.twitter.util.{Closable, Future, Time}
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
-import com.twitter.zipkin.zookeeper.ZooKeeperClientFactory
 
 trait KafkaSpanReceiverFactory { self: App =>
   val defaultZookeeperServer = "localhost:2181"

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaSpanReceiver.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaSpanReceiver.scala
@@ -16,7 +16,7 @@ trait KafkaSpanReceiverFactory { self: App =>
   val defaultKafkaSessionTimeout = "4000"
   val defaultKafkaSyncTime = "200"
   val defaultKafkaAutoOffset = "largest"
-  val defaultKafkaTopics = Map("test" -> 1)
+  val defaultKafkaTopics = Map("zipkin_kafka" -> 1)
 
   val kafkaTopics = flag[Map[String, Int]]("zipkin.kafka.topics", defaultKafkaTopics, "kafka topics to collect from")
   val kafkaServer = flag("zipkin.kafka.server", defaultZookeeperServer, "kafka server to connect")

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaSpanReceiver.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaSpanReceiver.scala
@@ -10,16 +10,16 @@ import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
 import com.twitter.zipkin.zookeeper.ZooKeeperClientFactory
 
 trait KafkaSpanReceiverFactory { self: App =>
-  val defaultKafkaServer = "127.0.0.1:2181"
+  val defaultZookeeperServer = "localhost:2181"
   val defaultKafkaGroupId = "zipkinId"
   val defaultKafkaZkConnectionTimeout = "1000000"
   val defaultKafkaSessionTimeout = "4000"
   val defaultKafkaSyncTime = "200"
   val defaultKafkaAutoOffset = "largest"
-  val defaultKafkaTopics = Map("topic" -> 1)
+  val defaultKafkaTopics = Map("test" -> 1)
 
   val kafkaTopics = flag[Map[String, Int]]("zipkin.kafka.topics", defaultKafkaTopics, "kafka topics to collect from")
-  val kafkaServer = flag("zipkin.kafka.server", defaultKafkaServer, "kafka server to connect")
+  val kafkaServer = flag("zipkin.kafka.server", defaultZookeeperServer, "kafka server to connect")
   val kafkaGroupId = flag("zipkin.kafka.groupid", defaultKafkaGroupId, "kafka group id")
   val kafkaZkConnectionTimeout = flag("zipkin.kafka.zk.connectionTimeout", defaultKafkaZkConnectionTimeout, "kafka zk connection timeout in ms")
   val kafkaSessionTimeout = flag("zipkin.kafka.zk.sessionTimeout", defaultKafkaSessionTimeout, "kafka zk session timeout in ms")
@@ -32,14 +32,13 @@ trait KafkaSpanReceiverFactory { self: App =>
     decoder: KafkaProcessor.KafkaDecoder
   ): SpanReceiver = new SpanReceiver {
 
-
     val props = new Properties() {
-      put("groupid", kafkaGroupId())
-      put("zk.connect", kafkaServer() )
-      put("zk.connectiontimeout.ms", kafkaZkConnectionTimeout())
-      put("zk.sessiontimeout.ms", kafkaSessionTimeout())
-      put("zk.synctime.ms", kafkaSyncTime())
-      put("autooffset.reset", kafkaAutoOffset())
+      put("group.id", kafkaGroupId())
+      put("zookeeper.connect", kafkaServer() )
+      put("zookeeper.connection.timeout.ms", kafkaZkConnectionTimeout())
+      put("zookeeper.session.timeout.ms", kafkaSessionTimeout())
+      put("zookeeper.sync.time.ms", kafkaSyncTime())
+      put("auto.offset.reset", kafkaAutoOffset())
     }
 
     val service = KafkaProcessor(kafkaTopics(), props, process, decoder)

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaStreamProcessor.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaStreamProcessor.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Await, Future}
 import java.io._
 
 case class KafkaStreamProcessor(
-  stream: KafkaStream[Option[List[ThriftSpan]]],
+  stream: KafkaStream[Option[List[ThriftSpan]],Option[List[ThriftSpan]]],
   process: Seq[ThriftSpan] => Future[Unit]
   ) extends Runnable {
 

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaStreamProcessor.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaStreamProcessor.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Await, Future}
 import java.io._
 
 case class KafkaStreamProcessor(
-  stream: KafkaStream[Option[List[ThriftSpan]]],
+  stream: KafkaStream[Option[List[ThriftSpan]], Option[List[ThriftSpan]]],
   process: Seq[ThriftSpan] => Future[Unit]
   ) extends Runnable {
 

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaStreamProcessor.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaStreamProcessor.scala
@@ -7,7 +7,7 @@ import com.twitter.util.{Await, Future}
 import java.io._
 
 case class KafkaStreamProcessor(
-  stream: KafkaStream[Option[List[ThriftSpan]],Option[List[ThriftSpan]]],
+  stream: KafkaStream[Option[List[ThriftSpan]]],
   process: Seq[ThriftSpan] => Future[Unit]
   ) extends Runnable {
 

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaStreamProcessor.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaStreamProcessor.scala
@@ -4,7 +4,6 @@ import com.twitter.logging.Logger
 import kafka.consumer.KafkaStream
 import com.twitter.zipkin.thriftscala.{Span => ThriftSpan}
 import com.twitter.util.{Await, Future}
-import java.io._
 
 case class KafkaStreamProcessor(
   stream: KafkaStream[Option[List[ThriftSpan]], Option[List[ThriftSpan]]],

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
@@ -105,7 +105,7 @@ class KafkaProcessorSpecSimple extends FunSuite with BeforeAndAfter {
     zkServer.shutdown
   }
 
-  test("kafka processor test simple2") {
+  test("kafka processor test") {
     val producer = new Producer[Array[Byte], Array[Byte]](new ProducerConfig(producerConfig))
     val message = createMessage()
     val data = new KeyedMessage("zipkin_kafka", "any".getBytes, message)

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
@@ -24,19 +24,20 @@ import java.io._
 
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
 import com.twitter.server.TwitterServer
-import com.twitter.zipkin.cassandra.CassieSpanStoreFactory
-import com.twitter.zipkin.storage.WriteSpanStore
+// import com.twitter.zipkin.cassandra.CassieSpanStoreFactory
+// import com.twitter.zipkin.storage.WriteSpanStore
 import com.twitter.zipkin.zookeeper.ZooKeeperClientFactory
 
 import java.util.Properties
 import com.twitter.zipkin.conversions.thrift._
 import com.twitter.app.{App, Flaggable}
+import com.twitter.zipkin.thriftscala
 
 @RunWith(classOf[JUnitRunner])
 class KafkaProcessorSpecSimple extends FunSuite with BeforeAndAfter {
 
-  val serializer = new BinaryThriftStructSerializer[ThriftSpan] {
-    def codec = ThriftSpan
+  val serializer = new BinaryThriftStructSerializer[thriftscala.Span] {
+    def codec = thriftscala.Span
   }
 
   val topic = Map("integration-test-topic" -> 1)
@@ -59,7 +60,7 @@ class KafkaProcessorSpecSimple extends FunSuite with BeforeAndAfter {
 
       def encode(span: Span) = {
         val gspan = spanToThriftSpan(span)
-        deserializer.toBytes(gspan.toThrift)
+        deserializer.toBytes(gspan)
       }
   }
 

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
@@ -1,0 +1,137 @@
+package com.twitter.zipkin.receiver.kafka
+
+import com.twitter.zipkin.receiver.test.kafka.{TestUtils, EmbeddedZookeeper}
+import com.twitter.zipkin.common._
+import com.twitter.zipkin.gen.{Span => ThriftSpan}
+import com.twitter.zipkin.conversions.thrift.{thriftSpanToSpan, spanToThriftSpan}
+import com.twitter.util.{Await, Future, Promise}
+import com.twitter.scrooge.BinaryThriftStructSerializer
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.BeforeAndAfter
+import org.scalatest.junit.JUnitRunner
+
+import kafka.consumer.{Consumer, ConsumerConnector, ConsumerConfig}
+import kafka.message.Message
+import kafka.producer._
+import kafka.serializer.Decoder
+import kafka.server.KafkaServer
+
+import kafka.serializer.Decoder
+import com.twitter.zipkin.collector.{SpanReceiver, ZipkinQueuedCollectorFactory}
+import java.io._
+
+import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
+import com.twitter.server.TwitterServer
+import com.twitter.zipkin.cassandra.CassieSpanStoreFactory
+import com.twitter.zipkin.storage.WriteSpanStore
+import com.twitter.zipkin.zookeeper.ZooKeeperClientFactory
+
+import java.util.Properties
+import com.twitter.zipkin.conversions.thrift._
+import com.twitter.app.{App, Flaggable}
+
+@RunWith(classOf[JUnitRunner])
+class KafkaProcessorSpecSimple extends FunSuite with BeforeAndAfter {
+
+  val serializer = new BinaryThriftStructSerializer[ThriftSpan] {
+    def codec = ThriftSpan
+  }
+
+  val topic = Map("integration-test-topic" -> 1)
+  val validSpan = Span(123, "boo", 456, None, List(new Annotation(1, "bah", None)), Nil)
+
+  case class TestDecoder extends Decoder[Option[List[ThriftSpan]]] {
+      val deserializer = serializer
+
+      def toEvent(message: Message): Option[List[ThriftSpan]] = {
+
+        val buffer = message.payload
+        val payload = new Array[Byte](buffer.remaining)
+        buffer.get(payload)
+
+        val span = deserializer.fromBytes(payload)
+        Some(List(span))
+      }
+
+      def fromBytes(bytes: Array[Byte]): Option[List[ThriftSpan]] = Some(List(deserializer.fromBytes(bytes)))
+
+      def encode(span: Span) = {
+        val gspan = spanToThriftSpan(span)
+        deserializer.toBytes(gspan.toThrift)
+      }
+  }
+
+  var zkServer: EmbeddedZookeeper = _
+  var testKafkaServer: KafkaServer = _
+  val producerConfig = TestUtils.kafkaProducerProps
+  val processorConfig = TestUtils.kafkaProcessorProps
+  val decoder = new TestDecoder()
+
+  def processorFun(spans: Seq[ThriftSpan]): Future[Unit] = {
+    assert( 1 == spans.length, "received more spans than sent" )
+    val message = spans.head.toSpan
+    assert(message.traceId == 1234, "traceId mismatch")
+    assert(message.name == "methodName", "method name mismatch")
+    assert(message.id == 4567, "spanId mismatch")
+    message.annotations map { a =>
+      assert(a.value == "value", "annotation name mismatch")
+      assert(a.timestamp == 1, "annotation timestamp mismatch")
+    }
+    Future.Done
+  }
+
+  def createMessage(): Array[Byte] = {
+    val annotation = Annotation(1, "value", Some(Endpoint(1, 2, "service")))
+    val message = Span(1234, "methodName", 4567, None, List(annotation), Nil)
+    val codec = new TestDecoder()
+    codec.encode(message)
+  }
+
+  before {
+    zkServer = TestUtils.startZkServer()
+    Thread.sleep(500)
+    testKafkaServer = TestUtils.startKafkaServer()
+    Thread.sleep(500)
+  }
+
+  after {
+    testKafkaServer.shutdown
+    zkServer.shutdown
+  }
+
+  val defaultZookeeperServer = "localhost:2181"
+  val defaultKafkaGroupId = "zipkinId"
+  val defaultKafkaSessionTimeout = "400"
+  val defaultKafkaSyncTime = "200"
+  val defaultKafkaAutoOffset = "largest"
+  val defaultKafkaTopics = Map("zipkin_kafka" -> 1 )
+
+  val proops = new Properties() {
+    put("group.id", defaultKafkaGroupId)
+    put("zookeeper.connect", defaultZookeeperServer)
+    put("zookeeper.session.timeout.ms", defaultKafkaSessionTimeout)
+    put("zookeeper.sync.time.ms", defaultKafkaSyncTime)
+    put("auto.offset.reset", defaultKafkaAutoOffset)
+  }
+
+  test("kafka processor test simple2") {
+    val producer = new Producer[Array[Byte], Array[Byte]](new ProducerConfig(producerConfig))
+    val message = createMessage()
+    val data = new KeyedMessage("zipkin_kafka", "any".getBytes, message)
+    val recvdSpan = new Promise[Option[Seq[ThriftSpan]]]
+
+    producer.send(data)
+    producer.close()
+
+    val service = KafkaProcessor(defaultKafkaTopics, processorConfig, { s =>
+        recvdSpan.setValue(Some(s))
+        Future.value(true)
+      }, new SpanDecoder)
+
+    Await.result(recvdSpan)
+    processorFun(recvdSpan.get().getOrElse(null))
+  }
+
+}

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
@@ -24,8 +24,6 @@ import java.io._
 
 import com.twitter.finagle.stats.{DefaultStatsReceiver, StatsReceiver}
 import com.twitter.server.TwitterServer
-// import com.twitter.zipkin.cassandra.CassieSpanStoreFactory
-// import com.twitter.zipkin.storage.WriteSpanStore
 import com.twitter.zipkin.zookeeper.ZooKeeperClientFactory
 
 import java.util.Properties

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/test/kafka/TestUtils.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/test/kafka/TestUtils.scala
@@ -9,10 +9,11 @@ import kafka.server.{KafkaServer, KafkaConfig}
 import kafka.utils.{Utils, ZKStringSerializer}
 
 import org.I0Itec.zkclient.ZkClient
-// import org.apache.commons.io.FileUtils
+import org.apache.commons.io.FileUtils
 import org.apache.zookeeper.server.{ZooKeeperServerMain, ServerConfig}
 import org.apache.zookeeper.server.NIOServerCnxn
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig
+import kafka.utils.SystemTime
 
 object TestUtils {
 

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/test/kafka/TestUtils.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/test/kafka/TestUtils.scala
@@ -1,0 +1,116 @@
+package com.twitter.zipkin.receiver.test.kafka
+
+import java.io.File
+import java.util.Random
+import java.net.{ServerSocket, InetSocketAddress}
+import java.util.Properties
+
+import kafka.server.{KafkaServer, KafkaConfig}
+import kafka.utils.{Utils, ZKStringSerializer}
+
+import org.I0Itec.zkclient.ZkClient
+import org.apache.commons.io.FileUtils
+import org.apache.zookeeper.server.{ZooKeeperServerMain, ServerConfig}
+import org.apache.zookeeper.server.NIOServerCnxn
+import org.apache.zookeeper.server.quorum.QuorumPeerConfig
+
+object TestUtils {
+
+  val seededRandom = new Random(192348092834L)
+  val random = new Random
+  val zookeeperConnect = "localhost:2181"
+
+
+  // 0 - kafka, 1 - zk
+  val ports = choosePorts(2)
+
+  def choosePorts(count: Int) = {
+    val sockets =
+      for(i <- 0 until count)
+        yield new ServerSocket(0)
+    val socketList = sockets.toList
+    val ports = socketList.map(_.getLocalPort)
+    ports
+  }
+
+  def choosePort(): Int = choosePorts(1).head
+
+  def tempDir(): File = {
+    val ioDir = System.getProperty("java.io.tempdir")
+    val f = new File(ioDir, "kafka-" + random.nextInt(10000000))
+    f.mkdirs
+    Runtime.getRuntime.addShutdownHook(new Thread { override def run() {
+      FileUtils.deleteDirectory(f)
+    }})
+    f
+  }
+
+  def startKafkaServer() = {
+    val logDir = tempDir()
+    val props = new Properties() {
+      put("host.name", "localhost")
+      put("port", ports(0).toString)
+      put("broker.id", "0")
+      put("log.dirs", String.valueOf(logDir))
+      put("zookeeper.connect", zookeeperConnect)
+    }
+    val kafkaServer = new KafkaServer(new KafkaConfig(props))
+    kafkaServer.startup
+    kafkaServer
+  }
+
+
+  def startZkServer() = {
+    val kafkaZkServer = new EmbeddedZookeeper(zookeeperConnect)
+    kafkaZkServer
+  }
+
+  def kafkaProducerProps = new Properties() {
+    put("producer.type"       , "sync")
+    put("metadata.broker.list", "localhost:" + ports(0).toString)
+    put("partitioner.class"   , "kafka.producer.DefaultPartitioner")
+    put("serializer.class"    , "kafka.serializer.DefaultEncoder");
+  }
+
+  def kafkaProcessorProps = new Properties() {
+    put("group.id"                    , "zipkinId")
+    put("zookeeper.connect"           , "localhost:2181")
+    put("auto.offset.reset"           , "smallest")
+    put("zookeeper.session.timeout.ms", "400")
+    put("zookeeper.sync.time.ms"      , "200")
+    put("auto.commit.interval.ms"     , "1000")
+  }
+
+}
+
+class EmbeddedZookeeper(connectString: String) {
+  val dataDir = TestUtils.tempDir()
+  val port = connectString.split(":")(1).toInt
+
+  val zkProps = new Properties {
+    put("dataDir"      , String.valueOf(dataDir))
+    put("clientPort"   , String.valueOf(port))
+    put("tickTime"     , "2000")
+    put("maxClientCnxs", "100")
+  }
+
+  val zk                      = new ZooKeeperServerMain()
+  val conf: ServerConfig      = new ServerConfig()
+  val qConf: QuorumPeerConfig = new QuorumPeerConfig()
+
+  qConf.parseProperties(zkProps)
+  conf.readFrom(qConf)
+
+  new Thread( new Runnable {
+    def run() {
+      zk.runFromConfig(conf)
+    }
+  }).start
+
+  val client = new ZkClient(connectString)
+  client.setZkSerializer(ZKStringSerializer)
+
+  def shutdown() {
+    Utils.rm(dataDir)
+  }
+}

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/test/kafka/TestUtils.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/test/kafka/TestUtils.scala
@@ -9,7 +9,7 @@ import kafka.server.{KafkaServer, KafkaConfig}
 import kafka.utils.{Utils, ZKStringSerializer}
 
 import org.I0Itec.zkclient.ZkClient
-import org.apache.commons.io.FileUtils
+// import org.apache.commons.io.FileUtils
 import org.apache.zookeeper.server.{ZooKeeperServerMain, ServerConfig}
 import org.apache.zookeeper.server.NIOServerCnxn
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig


### PR DESCRIPTION
Integrate kafka as the transport between the zipkin tracer and zipkin.  This allows us to remove scribe.

* update kafka to 0.8.1.1
* update zipkin tracer to use kafka
* update integration test
* starts kafka receiver on collector startup