### PR TITLE
Add wait to kafka stream processor

### DIFF
--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/util/Retry.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/util/Retry.scala
@@ -9,7 +9,7 @@ package com.twitter.zipkin.storage.util
  * supplied function is resilient to this fact.
  */
 object Retry {
-  def apply[T](n: Int)(f: => T) : T = {
+  def apply[T](n: Int, sleep: Boolean = false)(f: => T) : T = {
     var result:Option[T] = None
     var throwable:Option[Throwable] = None
 
@@ -17,7 +17,10 @@ object Retry {
       try {
         result = Option(f)
       } catch {
-        case e:Throwable => { throwable = Some(e) }
+        case e: Throwable => {
+            if (sleep) Thread.sleep(1000)
+            throwable = Some(e)
+          }
       }
     }
 
@@ -27,5 +30,6 @@ object Retry {
 
     result.get
   }
+
   class RetriesExhaustedException(msg:String, throwable:Throwable) extends RuntimeException(msg,throwable)
 }

--- a/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/utils/RetrySpec.scala
+++ b/zipkin-hbase/src/test/scala/com/twitter/zipkin/storage/hbase/utils/RetrySpec.scala
@@ -34,6 +34,20 @@ class RetrySpec extends SpecificationWithJUnit {
       }
       result must_== LongWrapper(10L)
     }
+    "sleeps when exception thrown and flag set" in {
+      val t1 = System.currentTimeMillis
+      try {
+        val result = Retry(2, true) {
+          throw new Exception
+        }
+      }
+      catch {
+        case e: Throwable => null
+      }
+      val t2 = System.currentTimeMillis
+      val delta = t2 - t1
+      delta >= 2
+    }
   }
   case class LongWrapper(value:Long)
 }

--- a/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaStreamProcessor.scala
+++ b/zipkin-receiver-kafka/src/main/scala/com/twitter/zipkin/receiver/kafka/KafkaStreamProcessor.scala
@@ -1,9 +1,13 @@
 package com.twitter.zipkin.receiver.kafka
 
 import com.twitter.logging.Logger
-import com.twitter.util.{Await, Future}
+import com.twitter.util._
 import com.twitter.zipkin.thriftscala.{Span => ThriftSpan}
 import kafka.consumer.KafkaStream
+import com.twitter.zipkin.collector.QueueFullException
+import kafka.message.MessageAndMetadata
+import scala.util.{Try, Success, Failure}
+import com.twitter.zipkin.storage.util.Retry
 
 case class KafkaStreamProcessor[T](
   stream: KafkaStream[T, List[ThriftSpan]],
@@ -11,14 +15,14 @@ case class KafkaStreamProcessor[T](
   ) extends Runnable {
 
   private[this] val log = Logger.get(getClass.getName)
+  private val retrycount = 5
 
   def run() {
     log.debug(s"${KafkaStreamProcessor.getClass.getName} run")
     try {
       stream foreach { msg =>
         log.debug(s"processing event ${msg.message()}")
-        // msg.message map { spans => Await.result(process(spans))}
-        Await.result(process(msg.message))
+        Retry(retrycount) { Await.ready(process(msg.message)) }
       }
     }
     catch {


### PR DESCRIPTION
During a load test the kafka consumer consumed messages at a rate faster than the ItemQueue could consume.  The blocking queue would throw `QueueFullException` and it was caught in a try/catch block.  Here we retry 5 times waiting 1 second in between attempts.
