### PR TITLE
Migrate db to use CQL3

### DIFF
--- a/zipkin-cassandra/src/schema/cassandra-schema-cql3.txt
+++ b/zipkin-cassandra/src/schema/cassandra-schema-cql3.txt
@@ -1,0 +1,73 @@
+CREATE KEYSPACE IF NOT EXISTS "Zipkin" WITH replication = {'class': 'NetworkTopologyStrategy', 'us-west': '2'};
+
+CREATE TABLE "Zipkin"."ServiceSpanNameIndex" (
+    key blob,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH CLUSTERING ORDER BY (column1 ASC)
+    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+
+CREATE TABLE "Zipkin"."TopAnnotations" (
+    key blob,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH CLUSTERING ORDER BY (column1 ASC)
+    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+
+CREATE TABLE "Zipkin"."ServiceNameIndex" (
+    key blob,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH CLUSTERING ORDER BY (column1 ASC)
+    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+
+CREATE TABLE "Zipkin"."SpanNames" (
+    key blob,
+    column1 blob,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH CLUSTERING ORDER BY (column1 ASC)
+    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+
+CREATE TABLE "Zipkin"."AnnotationsIndex" (
+    key blob,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH CLUSTERING ORDER BY (column1 ASC)
+    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+
+CREATE TABLE "Zipkin"."Dependencies" (
+    key blob,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH CLUSTERING ORDER BY (column1 ASC)
+    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+
+CREATE TABLE "Zipkin"."ServiceNames" (
+    key blob,
+    column1 blob,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH CLUSTERING ORDER BY (column1 ASC)
+    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+
+CREATE TABLE "Zipkin"."DurationIndex" (
+    key blob,
+    column1 bigint,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH CLUSTERING ORDER BY (column1 ASC)
+    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};
+
+CREATE TABLE "Zipkin"."Traces" (
+    key blob,
+    column1 blob,
+    value blob,
+    PRIMARY KEY (key, column1)
+) WITH CLUSTERING ORDER BY (column1 ASC)
+    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'};


### PR DESCRIPTION
Since cassandra-cli has been deprecated, we now need to load the db via cqlsh.  This is to allow it to be compatible.
