### PR TITLE
Propogate exceptions

### DIFF
--- a/zipkin-cassandra/src/main/scala/com/twitter/cassie/tests/util/FakeCassandra.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/cassie/tests/util/FakeCassandra.scala
@@ -263,7 +263,7 @@ class FakeCassandra extends Cassandra.Iface {
       true
     }
     else{
-      throw new AuthorizationException
+      throw new AuthorizationException("[fake]bad user/pass")
     }
   }
 

--- a/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraStorageTest.scala
+++ b/zipkin-cassandra/src/test/scala/com/twitter/zipkin/storage/cassandra/CassandraStorageTest.scala
@@ -66,6 +66,15 @@ class CassandraStorageTest extends FunSuite with BeforeAndAfter {
     assert(keyspaceBuilder.password == pass)
   }
 
+  test("raises authorization exception") {
+    val keyspaceBuilder = Keyspace.static(port = FakeServer.port.get, username = "bad", password = "creds")
+    val builder = StorageBuilder(keyspaceBuilder)
+    cassandraStorage = builder.apply()
+    intercept[org.apache.cassandra.finagle.thrift.AuthorizationException] {
+      Await.result(cassandraStorage.storeSpan(span1))
+    }
+  }
+
   test("getSpansByTraceId") {
     Await.result(cassandraStorage.storeSpan(span1))
     val spans = Await.result(cassandraStorage.getSpansByTraceId(span1.traceId))


### PR DESCRIPTION
- propagate auth exceptions to output
- add some exception text to fake cassandra

@oscil8 @trane @rkuris @mbbx6spp

We can now see Authentication exceptions like this:
![screen shot 2015-03-25 at 9 00 56 am](https://cloud.githubusercontent.com/assets/473680/6828920/89298ae6-d2cd-11e4-9311-2fd3011f9bd2.png)
