### PR TITLE
Bintray publish

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,3 @@
-import bintray.AttrMap
-import bintray._
-
 name := "zipkin"
 
 organization := "com.twitter"
@@ -9,16 +6,10 @@ scalaVersion := "2.9.3"
 
 publishMavenStyle := false
 
-seq(bintraySettings:_*)
-
-bintrayPublishSettings
-
-version := "1.2.0"
-
-bintray.Keys.repository in bintray.Keys.bintray := "sbt-plugins"
+version := "1.2.01"
 
 licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 
-bintray.Keys.repository in bintray.Keys.bintray := "zipkin"
+bintrayRepository := "zipkin"
 
-bintray.Keys.bintrayOrganization in bintray.Keys.bintray := Some("lookout")
+bintrayOrganization := Some("lookout")

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,8 @@ version := "1.2.01"
 
 licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 
-bintrayRepository := "zipkin"
+// bintray values below only affect the top level aggregator project, check Project.scala for default settings per sub project
 
 bintrayOrganization := Some("lookout")
+
+bintrayRepository := "zipkin"

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -22,8 +22,11 @@ import Keys._
 import sbtassembly.Plugin._
 import AssemblyKeys._
 
+
 object Zipkin extends Build {
-  val zipkinVersion = "1.2.01"
+  import bintray.BintrayKeys._
+
+  val zipkinVersion = "1.2.02"
 
   val finagleVersion = "6.22.0"
   val utilVersion = "6.22.1"
@@ -76,6 +79,8 @@ object Zipkin extends Build {
     version := zipkinVersion,
     crossScalaVersions := Seq("2.10.4"),
     scalaVersion := "2.10.4",
+    bintrayOrganization := Some("lookout"),
+    bintrayRepository := "zipkin",
     crossPaths := false,            /* Removes Scala version from artifact name */
     fork := true, // forking prevents runaway thread pollution of sbt
     baseDirectory in run := file(cwd) // necessary for forking
@@ -121,7 +126,7 @@ object Zipkin extends Build {
       id = "zipkin",
       base = file("."),
       settings = Seq(publish := {})
-    ) aggregate(
+    ).aggregate(
       tracegen, common, scrooge, zookeeper,
       query, queryCore, queryService, web,
       collectorScribe, collectorCore, collectorService,

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -23,7 +23,7 @@ import sbtassembly.Plugin._
 import AssemblyKeys._
 
 object Zipkin extends Build {
-  val zipkinVersion = "1.2.0-SNAPSHOT"
+  val zipkinVersion = "1.2.01"
 
   val finagleVersion = "6.22.0"
   val utilVersion = "6.22.1"
@@ -78,8 +78,7 @@ object Zipkin extends Build {
     scalaVersion := "2.10.4",
     crossPaths := false,            /* Removes Scala version from artifact name */
     fork := true, // forking prevents runaway thread pollution of sbt
-    baseDirectory in run := file(cwd), // necessary for forking
-    publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath + "/.ivy2/local")))
+    baseDirectory in run := file(cwd) // necessary for forking
   )
 
   // settings from inlined plugins
@@ -120,7 +119,8 @@ object Zipkin extends Build {
   lazy val zipkin =
     Project(
       id = "zipkin",
-      base = file(".")
+      base = file("."),
+      settings = Seq(publish := {})
     ) aggregate(
       tracegen, common, scrooge, zookeeper,
       query, queryCore, queryService, web,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.6
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,6 +20,6 @@ resolvers += Resolver.url(
 url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
 Resolver.ivyStylePatterns)
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
 resolvers += Classpaths.sbtPluginReleases

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,6 +20,6 @@ resolvers += Resolver.url(
 url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
 Resolver.ivyStylePatterns)
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-
 resolvers += Classpaths.sbtPluginReleases
+
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
- update sbt to 0.13.8
- don't publish top level aggregator project, its empty
- add bintray org and repo
- update bintray-sbt plugin to 0.3.0
