### PR TITLE
bump hermann 0.24 and finagle-thrift 1.4.1

### DIFF
--- a/zipkin-gems/zipkin-tracer/.gitignore
+++ b/zipkin-gems/zipkin-tracer/.gitignore
@@ -29,3 +29,6 @@ build/
 # Gemfile.lock
 .ruby-version
 .ruby-gemset
+
+# do not include Gemfile.lock in gem source
+Gemfile.lock

--- a/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
+++ b/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
@@ -31,12 +31,12 @@ Gem::Specification.new do |s|
   s.files                     = Dir.glob("{bin,lib}/**/*")
   s.require_path              = 'lib'
 
-  s.add_dependency "finagle-thrift", "~> 1.3.0"
+  s.add_dependency "finagle-thrift", "~> 1.4"
   s.add_dependency "scribe", "~> 0.2.4"
   s.add_dependency "rack"
 
   if RUBY_PLATFORM == "java"
-    s.add_dependency 'hermann', "~> 0.23"
+    s.add_dependency 'hermann', "~> 0.24"
     s.platform = 'java'
   end
 


### PR DESCRIPTION
This change rolls in:
- latest minor revision of hermann (kafka client)
- finagle-thrift 1.4.1 - which contains a [concurrency fix](https://github.com/twitter/finagle/pull/363)
