### PR TITLE
Try to close kafka ports on shutdown

### DIFF
--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/kafka/KafkaProcessorSpec.scala
@@ -73,6 +73,7 @@ class KafkaProcessorSpecSimple extends FunSuite with BeforeAndAfter {
   after {
     testKafkaServer.shutdown
     zkServer.shutdown
+    TestUtils.closePorts()
   }
 
   test("kafka processor test") {

--- a/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/test/kafka/TestUtils.scala
+++ b/zipkin-receiver-kafka/src/test/scala/com/twitter/zipkin/receiver/test/kafka/TestUtils.scala
@@ -45,7 +45,9 @@ object TestUtils {
     f
   }
 
-
+  def closePorts() = {
+    ports.map( port => new ServerSocket(port).close() )
+  }
 
   def startKafkaServer() = {
     val logDir = tempDir()


### PR DESCRIPTION
Kafka ports are not getting closed properly, this makes an attempt to close gracefully, thus not leading the port in an open state for the next travis build.

Do not review, this is being tested in travis!
