### PR TITLE
Make dependency on Hermann optional

### DIFF
--- a/zipkin-gems/zipkin-tracer/lib/zipkin-tracer.rb
+++ b/zipkin-gems/zipkin-tracer/lib/zipkin-tracer.rb
@@ -17,7 +17,12 @@ require 'scribe'
 require 'zipkin-tracer/careless_scribe'
 
 if RUBY_PLATFORM == 'java'
-  require 'zipkin-tracer/zipkin_kafka_tracer'
+  begin
+    require 'hermann/producer'
+  rescue LoadError
+    # Hermann not available
+  end
+  require 'zipkin-tracer/zipkin_kafka_tracer' if defined?(Hermann)
 end
 
 module ZipkinTracer extend self

--- a/zipkin-gems/zipkin-tracer/lib/zipkin-tracer.rb
+++ b/zipkin-gems/zipkin-tracer/lib/zipkin-tracer.rb
@@ -44,7 +44,7 @@ module ZipkinTracer extend self
         careless_scribe = CarelessScribe.new(scribe)
         scribe_max_buffer = config[:scribe_max_buffer] ? config[:scribe_max_buffer] : 10
         ::Trace.tracer = ::Trace::ZipkinTracer.new(careless_scribe, scribe_max_buffer)
-      elsif config[:zookeeper] && RUBY_PLATFORM == 'java'
+      elsif config[:zookeeper] && RUBY_PLATFORM == 'java' && defined?(Hermann)
         kafkaTracer = ::Trace::ZipkinKafkaTracer.new
         kafkaTracer.connect(config[:zookeeper])
         ::Trace.tracer = kafkaTracer

--- a/zipkin-gems/zipkin-tracer/lib/zipkin-tracer/version.rb
+++ b/zipkin-gems/zipkin-tracer/lib/zipkin-tracer/version.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end
 

--- a/zipkin-gems/zipkin-tracer/spec/zipkin_kafka_tracer_spec.rb
+++ b/zipkin-gems/zipkin-tracer/spec/zipkin_kafka_tracer_spec.rb
@@ -50,17 +50,17 @@ if RUBY_PLATFORM == 'java'
     end
 
     describe '#record' do
-      module Trace
-        class BinaryAnnotation
+      module MockTrace
+        class BinaryAnnotation < Trace::BinaryAnnotation
           def initialize;end
         end
-        class Annotation
+        class Annotation < Trace::Annotation
           def initialize;end
         end
       end
 
-      let(:binary_annotation) { ::Trace::BinaryAnnotation.new }
-      let(:annotation)        { ::Trace::Annotation.new }
+      let(:binary_annotation) { MockTrace::BinaryAnnotation.new }
+      let(:annotation)        { MockTrace::Annotation.new }
 
       it 'returns if id already sampled' do
         allow(id).to receive(:sampled?) { false }

--- a/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
+++ b/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
@@ -35,11 +35,6 @@ Gem::Specification.new do |s|
   s.add_dependency "scribe", "~> 0.2.4"
   s.add_dependency "rack"
 
-  if RUBY_PLATFORM == "java"
-    s.add_dependency 'hermann', "~> 0.24"
-    s.platform = 'java'
-  end
-
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "rack-test"
 end

--- a/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
+++ b/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
@@ -37,4 +37,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "rack-test"
+
+  # Hermann is an optional dependency. We had it here so we can run unit tests
+  s.add_development_dependency 'hermann', "~> 0.24"
 end

--- a/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
+++ b/zipkin-gems/zipkin-tracer/zipkin-tracer.gemspec
@@ -32,12 +32,12 @@ Gem::Specification.new do |s|
   s.require_path              = 'lib'
 
   s.add_dependency "finagle-thrift", "~> 1.4"
-  s.add_dependency "scribe", "~> 0.2.4"
   s.add_dependency "rack"
 
   s.add_development_dependency "rspec", "~> 3.0.0"
   s.add_development_dependency "rack-test"
 
-  # Hermann is an optional dependency. We had it here so we can run unit tests
+  # Hermann & Scribe are optional dependencies. We add them here so we can run unit tests
   s.add_development_dependency 'hermann', "~> 0.24"
+  s.add_development_dependency "scribe", "~> 0.2.4"
 end


### PR DESCRIPTION
We don't currently use Hermann. The latest version of lookout-zipkin would crash on book because of a LoadError.
